### PR TITLE
Add SectionServiceProxy for section management

### DIFF
--- a/Duo/Services/SectionServiceProxy.cs
+++ b/Duo/Services/SectionServiceProxy.cs
@@ -1,51 +1,57 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Duo.Models.Sections;
 
-
-
-
-public SectionServiceProxy(HttpClient httpClient)
+public class SectionServiceProxy
 {
-    this.httpClient = httpClient;
-}
+    private readonly HttpClient httpClient;
 
-public async Task<int> AddSection(Section section)
-{
-    var response = await httpClient.PostAsJsonAsync("api/sections/add", section);
-    response.EnsureSuccessStatusCode();
-    return await response.Content.ReadFromJsonAsync<int>();
-}
+    public SectionServiceProxy(HttpClient httpClient)
+    {
+        this.httpClient = httpClient;
+    }
 
-public async Task<int> CountSectionsFromRoadmap(int roadmapId)
-{
-    return await httpClient.GetFromJsonAsync<int>($"api/sections/count/{roadmapId}");
-}
+    public async Task<int> AddSection(Section section)
+    {
+        var response = await httpClient.PostAsJsonAsync("api/sections/add", section);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<int>();
+    }
 
-public async Task DeleteSection(int sectionId)
-{
-    await httpClient.DeleteAsync($"api/sections/{sectionId}");
-}
+    public async Task<int> CountSectionsFromRoadmap(int roadmapId)
+    {
+        return await httpClient.GetFromJsonAsync<int>($"api/sections/count/{roadmapId}");
+    }
 
-public async Task<List<Section>> GetAllSections()
-{
-    return await httpClient.GetFromJsonAsync<List<Section>>("api/sections");
-}
+    public async Task DeleteSection(int sectionId)
+    {
+        await httpClient.DeleteAsync($"api/sections/{sectionId}");
+    }
 
-public async Task<List<Section>> GetByRoadmapId(int roadmapId)
-{
-    return await httpClient.GetFromJsonAsync<List<Section>>($"api/sections/roadmap/{roadmapId}");
-}
+    public async Task<List<Section>> GetAllSections()
+    {
+        return await httpClient.GetFromJsonAsync<List<Section>>("api/sections");
+    }
 
-public async Task<Section> GetSectionById(int sectionId)
-{
-    return await httpClient.GetFromJsonAsync<Section>($"api/sections/{sectionId}");
-}
+    public async Task<List<Section>> GetByRoadmapId(int roadmapId)
+    {
+        return await httpClient.GetFromJsonAsync<List<Section>>($"api/sections/roadmap/{roadmapId}");
+    }
 
-public async Task<int> LastOrderNumberFromRoadmap(int roadmapId)
-{
-    return await httpClient.GetFromJsonAsync<int>($"api/sections/lastordernumber/{roadmapId}");
-}
+    public async Task<Section> GetSectionById(int sectionId)
+    {
+        return await httpClient.GetFromJsonAsync<Section>($"api/sections/{sectionId}");
+    }
 
-public async Task UpdateSection(Section section)
-{
-    await httpClient.PutAsJsonAsync("api/sections/update", section);
-}
+    public async Task<int> LastOrderNumberFromRoadmap(int roadmapId)
+    {
+        return await httpClient.GetFromJsonAsync<int>($"api/sections/lastordernumber/{roadmapId}");
+    }
+
+    public async Task UpdateSection(Section section)
+    {
+        await httpClient.PutAsJsonAsync("api/sections/update", section);
+    }
 }


### PR DESCRIPTION
Introduced the `SectionServiceProxy` class to handle section-related operations via HTTP requests. This new implementation includes methods for adding, counting, deleting, retrieving, and updating sections, utilizing an injected `HttpClient`. The previous code has been removed and replaced with this organized structure.