### PR TITLE
Updated api repo tests. Added a DTO class to replace an anonymous class.

### DIFF
--- a/Duo.Api/DTO/QuizResultDTO.cs
+++ b/Duo.Api/DTO/QuizResultDTO.cs
@@ -1,0 +1,14 @@
+﻿namespace Duo.Api.DTO
+{
+    public class QuizResultDTO
+    {
+        public int QuizId { get; set; }
+        public int ExercisesCount { get; set; }
+
+        public QuizResultDTO(int quizId, int exercisesCount)
+        {
+            QuizId = quizId;
+            ExercisesCount = exercisesCount;
+        }
+    }
+}

--- a/Duo.Api/Repositories/IRepository.cs
+++ b/Duo.Api/Repositories/IRepository.cs
@@ -1,3 +1,4 @@
+using Duo.Api.DTO;
 using Duo.Api.Models;
 using Duo.Api.Models.Exercises;
 using Duo.Api.Models.Quizzes;
@@ -57,7 +58,7 @@ namespace Duo.Api.Repositories
         Task AddExercisesToQuizAsync(int quizId, List<int> exerciseIds);
         Task AddExerciseToQuizAsync(int quizId, int exerciseId);
         Task RemoveExerciseFromQuizAsync(int quizId, int exerciseId);
-        Task<object> GetQuizResultAsync(int quizId);
+        Task<QuizResultDTO> GetQuizResultAsync(int quizId);
         #endregion
 
         #region Courses

--- a/Duo.Api/Repositories/Repository.cs
+++ b/Duo.Api/Repositories/Repository.cs
@@ -1,3 +1,4 @@
+using Duo.Api.DTO;
 using Duo.Api.Models;
 using Duo.Api.Models.Exercises;
 using Duo.Api.Models.Quizzes;
@@ -316,7 +317,7 @@ namespace Duo.Api.Repositories
         /// <summary>
         /// Gets the quiz result. (for now just returns the quiz data, adjust if more needed)
         /// </summary>
-        public async Task<object> GetQuizResultAsync(int quizId)
+        public async Task<QuizResultDTO> GetQuizResultAsync(int quizId)
         {
             var quiz = await context.Quizzes
                 .Include(q => q.Exercises)
@@ -326,11 +327,11 @@ namespace Duo.Api.Repositories
                 return null;
 
             // Basic mock result, you can change this based on your real app requirements
-            return new
-            {
-                QuizId = quiz.Id,
-                ExerciseCount = quiz.Exercises.Count
-            };
+            return new QuizResultDTO
+            (
+                quiz.Id,
+                quiz.Exercises.Count
+            );
         }
         #endregion
 


### PR DESCRIPTION
This pull request introduces a new `QuizResultDTO` class to standardize the representation of quiz results and updates the repository interface and implementation to use this DTO instead of an anonymous object. These changes improve type safety and make the codebase more maintainable. This pull request also adds missing tests for some repository methods.

### Introduction of `QuizResultDTO`:

* Created a new `QuizResultDTO` class in `Duo.Api/DTO/QuizResultDTO.cs` to encapsulate quiz result data, including `QuizId` and `ExercisesCount`.

### Updates to repository interface and implementation:

* Updated the `IRepository` interface to replace the return type of `GetQuizResultAsync` from `object` to `QuizResultDTO`, ensuring type safety.
* Modified the `Repository` class to return a `QuizResultDTO` instance in `GetQuizResultAsync` instead of an anonymous object, aligning with the new DTO structure. [[1]](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5L319-R320) [[2]](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5L329-R334)

### Namespace and import adjustments:

* Added `using Duo.Api.DTO` in both `IRepository.cs` and `Repository.cs` to include the newly created `QuizResultDTO` class. [[1]](diffhunk://#diff-6381e50ae3c043b53e2ae625a91f1cc092a6b9a6aee0e2992f29a7eba927897fR1) [[2]](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5R1)