### PR TITLE
Finalised all tests for api repo.

### DIFF
--- a/Duo.Api/Controllers/QuizController.cs
+++ b/Duo.Api/Controllers/QuizController.cs
@@ -1,11 +1,11 @@
-
-using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Duo.Api.Models.Exercises;
 using Duo.Api.Models.Quizzes;
 using Duo.Api.Persistence;
 using Duo.Api.Repositories;
-using Duo.Api.Models.Exercises;
+using Duo.Models.Quizzes.API;
+using Microsoft.AspNetCore.Mvc;
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
 
@@ -163,7 +163,9 @@ namespace Duo.Api.Controllers
         {
             var quiz = await repository.GetQuizByIdAsync(submission.QuizId);
             if (quiz == null)
+            {
                 return NotFound();
+            }
 
             var submissionEntity = new QuizSubmissionEntity
             {
@@ -242,7 +244,9 @@ namespace Duo.Api.Controllers
         {
             var submission = await repository.GetSubmissionByQuizIdAsync(quizId);
             if (submission == null)
+            {
                 return NotFound();
+            }
 
             var result = new QuizResult
             {

--- a/Duo.Api/Models/Quizzes/QuizSubmissionEntity.cs
+++ b/Duo.Api/Models/Quizzes/QuizSubmissionEntity.cs
@@ -13,7 +13,8 @@ namespace Duo.Api.Models.Quizzes
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
 
-        public List<AnswerSubmissionEntity> Answers { get; set; } = new();
+        public List<AnswerSubmissionEntity> Answers { get; set; } =
+            [];
     }
 
     public class AnswerSubmissionEntity

--- a/Duo.Api/Repositories/IRepository.cs
+++ b/Duo.Api/Repositories/IRepository.cs
@@ -3,6 +3,7 @@ using Duo.Api.Models;
 using Duo.Api.Models.Exercises;
 using Duo.Api.Models.Quizzes;
 using Duo.Api.Models.Sections;
+using Duo.Models.Quizzes.API;
 
 namespace Duo.Api.Repositories
 {
@@ -290,17 +291,10 @@ namespace Duo.Api.Repositories
         public Task RemoveExerciseFromQuizAsync(int quizId, int exerciseId);
 
         /// <summary>
-        /// Retrieves the result of a quiz asynchronously.
-        /// </summary>
-        /// <param name="quizId">The unique identifier of the quiz whose result is to be retrieved.</param>
-        /// <returns>An object representing the quiz result, which can be customized as needed.</returns>
-        public Task<QuizResultDTO?> GetQuizResultAsync(int quizId);
-
-        /// <summary>
         /// Saves a quiz submitted by a user
         /// </summary>
         /// <param name="submission">Submitted quiz entity</param>
-        /// <returns>A task representing the asynchronous operation</returns> 
+        /// <returns>A task representing the asynchronous operation</returns>
         Task SaveQuizSubmissionAsync(QuizSubmissionEntity submission);
 
         /// <summary>

--- a/Duo.Api/Repositories/Repository.cs
+++ b/Duo.Api/Repositories/Repository.cs
@@ -4,6 +4,7 @@ using Duo.Api.Models.Exercises;
 using Duo.Api.Models.Quizzes;
 using Duo.Api.Models.Sections;
 using Duo.Api.Persistence;
+using Duo.Models.Quizzes.API;
 using Microsoft.EntityFrameworkCore;
 
 #pragma warning disable IDE0079 // Remove unnecessary suppression
@@ -597,29 +598,6 @@ namespace Duo.Api.Repositories
                 await context.SaveChangesAsync();
             }
         }
-
-        /// <summary>
-        /// Gets the quiz result, including the quiz ID and the count of associated exercises.
-        /// </summary>
-        /// <param name="quizId">The unique identifier of the quiz.</param>
-        /// <returns>An object containing the quiz ID and the count of exercises, or <c>null</c> if the quiz does not exist.</returns>
-        public async Task<QuizResultDTO?> GetQuizResultAsync(int quizId)
-        {
-            var quiz = await context.Quizzes
-                .Include(q => q.Exercises)
-                .FirstOrDefaultAsync(q => q.Id == quizId);
-
-            if (quiz == null)
-            {
-                return null;
-            }
-
-            // Basic mock result
-            return new QuizResultDTO(
-                quiz.Id,
-                quiz.Exercises.Count);
-        }
-
         #endregion
 
         #region Courses


### PR DESCRIPTION
This pull request includes improvements to error handling, cleanup of unused code, and minor adjustments to data initialization in the `QuizController` and related files. The most important changes include adding braces for better readability in error handling, removing the `GetQuizResultAsync` method from the repository, and adjusting the initialization of the `Answers` property in `QuizSubmissionEntity`.

### Improvements to error handling:
* Added braces to `if` conditions in `SubmitQuiz` and `GetQuizResult` methods in `QuizController` to improve readability and maintainability. (`Duo.Api/Controllers/QuizController.cs`, [[1]](diffhunk://#diff-808d8eebdead8c4fdbc811e14ecf5c274b5589d8fe1b685173446ce369ad6bb6R166-R168) [[2]](diffhunk://#diff-808d8eebdead8c4fdbc811e14ecf5c274b5589d8fe1b685173446ce369ad6bb6R247-R249)

### Code cleanup:
* Removed the unused `GetQuizResultAsync` method from the `IRepository` interface and its implementation in `Repository`. This method was no longer needed and has been fully removed from the codebase. (`Duo.Api/Repositories/IRepository.cs`, [[1]](diffhunk://#diff-6381e50ae3c043b53e2ae625a91f1cc092a6b9a6aee0e2992f29a7eba927897fL292-L298); `Duo.Api/Repositories/Repository.cs`, [[2]](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5L600-L622)

### Data initialization adjustments:
* Adjusted the initialization of the `Answers` property in `QuizSubmissionEntity` to use a multi-line format for better readability. (`Duo.Api/Models/Quizzes/QuizSubmissionEntity.cs`, [Duo.Api/Models/Quizzes/QuizSubmissionEntity.csL16-R17](diffhunk://#diff-d4312443ff0cc97fb71e7dd704648705940770f567a7dc4aecab76d162cdc05fL16-R17))

### Namespace updates:
* Added a missing namespace reference (`Duo.Models.Quizzes.API`) in multiple files to ensure proper type resolution. (`Duo.Api/Controllers/QuizController.cs`, [[1]](diffhunk://#diff-808d8eebdead8c4fdbc811e14ecf5c274b5589d8fe1b685173446ce369ad6bb6L1-R8); `Duo.Api/Repositories/IRepository.cs`, [[2]](diffhunk://#diff-6381e50ae3c043b53e2ae625a91f1cc092a6b9a6aee0e2992f29a7eba927897fR6); `Duo.Api/Repositories/Repository.cs`, [[3]](diffhunk://#diff-c289686ff14a6189ca019b7be48d801bcec670be0b9bbeab8a175b36bd09e7c5R7)